### PR TITLE
[fix] Missing card dependency declaration

### DIFF
--- a/packages/movies-content/package.json
+++ b/packages/movies-content/package.json
@@ -16,6 +16,7 @@
     "eslint-config-custom": "workspace:*",
     "react": "^18.1.0",
     "store": "workspace:*",
+    "card": "workspace:*",
     "tsconfig": "workspace:*",
     "typescript": "^4.5.2"
   },

--- a/packages/playlist-content/package.json
+++ b/packages/playlist-content/package.json
@@ -16,6 +16,7 @@
     "eslint-config-custom": "workspace:*",
     "react": "^18.1.0",
     "store": "workspace:*",
+    "card": "workspace:*",
     "tsconfig": "workspace:*",
     "typescript": "^4.5.2"
   },


### PR DESCRIPTION
I've noticed the following error when running the build command:

```
movies-content:build: MoviesContent.tsx(3,27): error TS2307: Cannot find module 'card' or its corresponding type declarations.
movies-content:build:  ELIFECYCLE  Command failed with exit code 2.
movies-content:build: ERROR: command finished with error: command (packages/movies-content) pnpm run build exited (1)
command (packages/movies-content) pnpm run build exited (1)
```

After adding it to the packages package.json it is building fine.