### PR TITLE
Make PORT var setting cross-platform safe:

### DIFF
--- a/apps/playlist/package.json
+++ b/apps/playlist/package.json
@@ -25,7 +25,7 @@
     "web-vitals": "^2.1.4"
   },
   "scripts": {
-    "dev": "PORT=3001 craco start",
+    "dev": "cross-env PORT=3001 craco start",
     "build": "craco build",
     "test": "craco test",
     "eject": "react-scripts eject"
@@ -49,6 +49,7 @@
     ]
   },
   "devDependencies": {
-    "@craco/craco": "^6.4.3"
+    "@craco/craco": "^6.4.3",
+    "cross-env": "^7.0.3"
   }
 }


### PR DESCRIPTION
- Setting an environment variable inside package.json script is different on Mac and Windows (set PORT=3001 && craco start). Instead, use the production tested 'cross-env' package to set it in a platform agnostic way.